### PR TITLE
add python3 shebang

### DIFF
--- a/textshot.py
+++ b/textshot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import ctypes
 import os
 import sys


### PR DESCRIPTION
This allows unix users to run `./textshot.py` instead of `python3 textshot.py`.

Might seem insignificant, but if the script is in the `PATH`, that means calling `textshot` from anywhere instead of `python3 /path/to/textshot.py` :)