### PR TITLE
make pynotifier optional

### DIFF
--- a/textshot.py
+++ b/textshot.py
@@ -5,7 +5,10 @@ import sys
 import pyperclip
 import pyscreenshot as ImageGrab
 import pytesseract
-from pynotifier import Notification
+try:
+    from pynotifier import Notification
+except ImportError:
+    pass
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 
@@ -87,7 +90,7 @@ def processImage(img):
 def notify(msg):
     try:
         Notification(title="TextShot", description=msg).send()
-    except SystemError:
+    except NameError:
         pass
 
 


### PR DESCRIPTION
Notifications are nice, but not vital to the app, so let's use them when
available, without crashing when they're not available.